### PR TITLE
Add Command+W hotkey

### DIFF
--- a/MacGap/Base.lproj/MainMenu.xib
+++ b/MacGap/Base.lproj/MainMenu.xib
@@ -56,6 +56,11 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                            <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                            <connections>
+                            <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
+                            </connections>
+                            </menuItem>
                             <menuItem title="Quit Aria2GUI" keyEquivalent="q" id="4sb-4s-VLi">
                                 <connections>
                                     <action selector="terminate:" target="-1" id="Te7-pn-YzF"/>


### PR DESCRIPTION
Added Command+W hotkey which macOS users would use very often so that they don’t need to click the small red dot on top left.